### PR TITLE
Support heavy-rotation members

### DIFF
--- a/LunchWagon.gs
+++ b/LunchWagon.gs
@@ -21,12 +21,13 @@ LunchWagon.prototype = {
   go: function() {
     var members = this.getMembers()
     this.saveToSheet(members)
+
     var attachments = [{
       title: 'ランダムにメンバーを選んでランチへ行く通知です',
       title_link: 'https://github.com/linyows/lunch-wagon.gs',
       color: '#ffc844',
       text: '行ける or 行けない をスレッドやリアクション絵文字などでお知らせください。'
-          + '参加者に変更があったら、 <' + this.sheetUrl + '|管理シート> を更新してください'
+          + '参加者に変更があったら、 <' + this.sheetUrl + '|管理シート> を更新してください。絶対だぞ :pray:'
     }]
     if (this.membersMustGo.length > 0) {
       attachments[0]['fields'] = [{
@@ -45,7 +46,7 @@ LunchWagon.prototype = {
       title: 'ランダムにメンバーを選んでランチへ行く通知です',
       title_link: 'https://github.com/linyows/lunch-wagon.gs',
       color: '#ffc844',
-      text: '参加者に変更があったら、 <' + this.sheetUrl + '|管理シート> を更新してください'
+      text: '参加者に変更があったら、 <' + this.sheetUrl + '|管理シート> を更新してください。絶対だぞ :heart:'
     }]
     this.notifyToSlack(this.buildFinalMessage(members), JSON.stringify(attachments))
   },
@@ -100,11 +101,13 @@ LunchWagon.prototype = {
       rowCount = rowIndex
       rowIndex = 1
     }
+
     var data = this.sheet().getSheetValues(rowIndex, columnIndex, rowCount, this.sheet().getLastColumn())
 
     var members = []
     for (var rowIndex = 0; rowIndex < data.length; rowIndex++) {
       var row = data[rowIndex]
+
       for (var colIndex = 0; colIndex < row.length; colIndex++) {
         if (row[colIndex].trim() !== '') {
           members.push(this.slackNameToId(row[colIndex].trim()))
@@ -124,6 +127,7 @@ LunchWagon.prototype = {
   },
   availableMembers: function() {
     var fullMembers = this.getMembersBySlack()
+
     var excludedMembers = this.excludedMembers()
     var members = []
     for (var i = 0; i < fullMembers.length; i++) {

--- a/LunchWagon.gs
+++ b/LunchWagon.gs
@@ -14,6 +14,7 @@ var LunchWagon = function() {
   this.partyCount = 4
   this.skipCount = 5
   this.membersNotGo = []
+  this.membersMustGo = []
 }
 
 LunchWagon.prototype = {
@@ -27,6 +28,12 @@ LunchWagon.prototype = {
       text: '行ける or 行けない をスレッドやリアクション絵文字などでお知らせください。'
           + '参加者に変更があったら、 <' + this.sheetUrl + '|管理シート> を更新してください'
     }]
+    if (this.membersMustGo.length > 0) {
+      attachments[0]['fields'] = [{
+        title: 'ヘビロテ メンバー :fire:',
+        value: this.membersMustGo.join(', ')
+      }]
+    }
     this.notifyToSlack(this.buildMessage(members), JSON.stringify(attachments))
   },
   notifyFinal: function() {
@@ -109,6 +116,10 @@ LunchWagon.prototype = {
       members.push(this.slackNameToId(this.membersNotGo[noGoIndex]))
     }
 
+    for (var mustGoIndex = 0; mustGoIndex < this.membersMustGo.length; mustGoIndex++) {
+      members.push(this.slackNameToId(this.membersMustGo[mustGoIndex]))
+    }
+
     return members
   },
   availableMembers: function() {
@@ -120,14 +131,22 @@ LunchWagon.prototype = {
         members.push(fullMembers[i])
       }
     }
+
     return members
   },
   getMembers: function() {
     var shuffled = this.shuffle(this.availableMembers())
     var members = []
-    for (var i = 0; i < this.partyCount; i++) {
+    var partyCount = this.partyCount - this.membersMustGo.lenght
+
+    for (var mustGoIndex = 0; mustGoIndex < this.membersMustGo.length; mustGoIndex++) {
+      members.push(this.slackNameToId(this.membersMustGo[mustGoIndex]))
+    }
+
+    for (var i = 0; i < partyCount; i++) {
       members.push(shuffled[i])
     }
+
     return members
   },
   shuffle: function(array) {


### PR DESCRIPTION
This change can always set members to participate in shuffle lunch.

Example:

![180803-0001](https://user-images.githubusercontent.com/72049/43621034-69f1b53a-9710-11e8-9cef-7d1109894707.png)